### PR TITLE
feat: dev setup and sync improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: comp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: cardano_metadata
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "55443:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d cardano_metadata"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/src/Cardano.Metadata/Models/Github/GitCommitFile.cs
+++ b/src/Cardano.Metadata/Models/Github/GitCommitFile.cs
@@ -3,5 +3,6 @@ namespace Cardano.Metadata.Models.Github;
 public record GitCommitFile
 {
     public string? Filename { get; set; }
+    public string? Status { get; set; }
     public string? RawUrl { get; set; }
 }

--- a/src/Cardano.Metadata/Workers/GithubWorker.cs
+++ b/src/Cardano.Metadata/Workers/GithubWorker.cs
@@ -70,6 +70,11 @@ public class GithubWorker
                         {
                             if (file.Filename is not null)
                             {
+                                if (string.Equals(file.Status, "removed", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    logger.LogInformation("Skipping removed file {Filename} in commit {Sha}", file.Filename, resolvedCommit.Sha);
+                                    continue;
+                                }
                                 var subject = ExtractSubjectFromPath(file.Filename);
 
                                 try

--- a/src/Cardano.Metadata/appsettings.example.json
+++ b/src/Cardano.Metadata/appsettings.example.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=55443;Database=cardano_metadata;Username=postgres;Password=postgres"
+  },
+  "GithubPAT": "REPLACE_WITH_YOUR_GITHUB_PAT",
+  "RegistryOwner": "cardano-foundation",
+  "RegistryRepo": "cardano-token-registry"
+}


### PR DESCRIPTION
## Summary
- Improve local developer setup and database availability.
- Keep DB schema in sync on startup.
- Make incremental sync quieter by skipping removed files.

## Changes
- docker: Add Postgres via docker-compose on host port `55443` with volume + healthcheck.
- config: Add `appsettings.example.json` for easy onboarding (PAT placeholder, DB matches compose).
- db: Auto-apply EF Core migrations on startup; fallback to `EnsureCreated` when no migrations exist.
- sync: Skip files where GitHub commit `files[].status` is `removed` (preserves history; no hard deletes).

## How To Run
- Start DB: `docker compose up -d db`
- Run app: `dotnet run` (from `src/Cardano.Metadata`)
- Verify DB (optional): `psql -h localhost -p 55443 -U postgres -d cardano_metadata -c 'SELECT COUNT(*) FROM "TokenMetadata";'`

## Notes
- `appsettings.json` is gitignored; config can also be supplied via environment variables (ASP.NET Core default config).
- Default connection string: `Host=localhost;Port=55443;Database=cardano_metadata;Username=postgres;Password=postgres`.

## Follow-ups (optional)
- Add `/health` endpoint for liveness.
- Scaffold initial EF migration (`dotnet ef migrations add InitialCreate`).
