### PR TITLE
feat(docker): Dockerfile and compose app service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Build artifacts
+**/bin/
+**/obj/
+
+# VCS
+.git
+.gitignore
+
+# IDE/editor
+.vs
+.vscode
+*.user
+*.suo
+
+# Docker (keep Dockerfile in context)
+
+# Misc
+*.log
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Multi-stage build for COMP (ASP.NET Core 9)
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Copy project files and restore as distinct layers for better caching
+COPY src/COMP/COMP.csproj src/COMP/
+RUN dotnet restore "src/COMP/COMP.csproj"
+
+# Copy the remaining source
+COPY . .
+
+# Publish to a self-contained directory (framework-dependent)
+RUN dotnet publish "src/COMP/COMP.csproj" -c Release -o /app/out --no-restore
+
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+# Copy app
+COPY --from=build /app/out .
+
+ENV DOTNET_EnableDiagnostics=0 \
+    ASPNETCORE_ENVIRONMENT=Production
+
+# Bind to Railway's dynamic $PORT (default 8080 locally) and run
+CMD ["sh", "-c", "ASPNETCORE_URLS=http://0.0.0.0:${PORT:-8080} dotnet COMP.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:16-alpine
@@ -18,6 +16,26 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: comp-app
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      # Bind to this port inside the container
+      PORT: "8080"
+      # Pass your GitHub PAT from host env (optional here; set in shell/CI)
+      GithubPAT: ${GithubPAT:-}
+      # Connect to the compose Postgres service
+      ConnectionStrings__DefaultConnection: Host=db;Port=5432;Database=cardano_metadata;Username=postgres;Password=postgres
+      ASPNETCORE_ENVIRONMENT: Development
+    ports:
+      - "8080:8080"
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
Add Dockerfile for COMP and a new `app` service in docker-compose for local/dev and deployment (e.g., Railway).

## Changes
- Dockerfile: multi-stage build, dynamic PORT binding via CMD, no EXPOSE.
- docker-compose: `app` service builds from Dockerfile, depends on healthy `db`, ports 8080:8080.
- .dockerignore: reduce context size.

## Run
- `docker compose up -d --build`
- App: http://localhost:8080
- DB: psql -h localhost -p 55443 -U postgres -d cardano_metadata

## Env
- `GithubPAT` (token)
- `ConnectionStrings__DefaultConnection` set in compose to `Host=db;Port=5432;...`
