### PR TITLE
chore(ci): publish Docker image on main + bump action versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,19 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
 
       - name: Set image name (lowercase)
         run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.8.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -43,7 +43,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Publish Docker image (main only)
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase)
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,branch=main
+            # Full commit SHA tag without the default 'sha-' prefix
+            type=sha,format=long,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
Publish Docker images for COMP to GHCR only when pushing to `main`, and update all GitHub Actions to latest stable versions.

## Changes
- Restrict workflow trigger to `push` on `main` only (no tags/branches).
- Image tagging:
  - Full commit SHA (no `sha-` prefix)
  - `latest` on default branch
  - `main`
- Bump actions to latest:
  - `actions/checkout@v5.0.0`
  - `docker/setup-qemu-action@v3.6.0`
  - `docker/setup-buildx-action@v3.11.1`
  - `docker/login-action@v3.5.0`
  - `docker/metadata-action@v5.8.0`
  - `docker/build-push-action@v6.18.0`

## Resulting tags (examples)
- `ghcr.io/${{ github.repository_owner }}/comp:latest`
- `ghcr.io/${{ github.repository_owner }}/comp:main`
- `ghcr.io/${{ github.repository_owner }}/comp:<40-char-commit-sha>`

## Security
- Uses `GITHUB_TOKEN` with `packages: write` permission.
- Latest action majors with pinned version tags.

## Usage
- After merge, any push to `main` builds and publishes the image to GHCR.
- Pull examples:
  - `docker pull ghcr.io/${{ github.repository_owner }}/comp:latest`
  - `docker pull ghcr.io/${{ github.repository_owner }}/comp:<commit-sha>`
